### PR TITLE
Take the average for operators over periods of time

### DIFF
--- a/cron_init.sh
+++ b/cron_init.sh
@@ -6,7 +6,7 @@ echo "*/30 * * * * /bin/sh /app/cron.sh &> /app/cron.log" >| train_crontab
 crontab train_crontab
 
 chmod 777 /app/cron.sh
-echo "Setup cron.sh" >> /app/cron.log
+echo "Setup cron.sh" >| /app/cron.log
 
 echo "Running cron"
 cron -f &

--- a/train_app/rankings.py
+++ b/train_app/rankings.py
@@ -13,11 +13,14 @@ bp = Blueprint("rankings", __name__, url_prefix="/")
 def index() -> str:
     """Show rankings."""
     db = get_db()
-    # Join the performance and operators on performance.operator_id = operators.id
+    # Get operator average rankings in the last 7 days, 30 days, and 90 days
     rankings = db.execute(
-        "SELECT operator.name, AVG(performance.ppm) AS ppm"
-        " FROM performance JOIN operator ON performance.operator_id = operator.id"
-        " GROUP BY operator.name"
-        " ORDER BY ppm DESC"
+        "SELECT operator.name, "
+        "ROUND(AVG(CASE WHEN date(performance.record_date) > date('now', '-7 days') THEN performance.ppm END), 2) AS average_rating_7_days, "
+        "ROUND(AVG(CASE WHEN date(performance.record_date) > date('now', '-30 days') THEN performance.ppm END), 2) AS average_rating_30_days, "
+        "ROUND(AVG(CASE WHEN date(performance.record_date) > date('now', '-90 days') THEN performance.ppm END), 2) AS average_rating_90_days "
+        "FROM performance JOIN operator ON performance.operator_id = operator.id "
+        "GROUP BY operator.name "
+        "ORDER BY average_rating_7_days DESC"
     ).fetchall()
     return render_template("rankings/index.html", rankings=rankings)

--- a/train_app/templates/about/index.html
+++ b/train_app/templates/about/index.html
@@ -28,7 +28,7 @@
   <ul>
     <li>
       The
-      <a href="https://wiki.openraildata.com//index.php?title=Main_Page"
+      <a href="https://wiki.openraildata.com/index.php?title=Main_Page"
         >Open Rail Data Wiki</a
       >
       contributors

--- a/train_app/templates/rankings/index.html
+++ b/train_app/templates/rankings/index.html
@@ -6,7 +6,9 @@
       <tr>
         <th>Ranking</th>
         <th>Operator</th>
-        <th>PPM</th>
+        <th>PPM (7 day avg)</th>
+        <th>PPM (30 day avg)</th>
+        <th>PPM (90 day avg)</th>
       </tr>
     </thead>
     <tbody>
@@ -14,7 +16,9 @@
       <tr>
         <td>{{ loop.index }}</td>
         <td>{{ operator.name }}</td>
-        <td>{{ operator.ppm }}</td>
+        <td>{{ operator.average_rating_7_days }}</td>
+        <td>{{ operator.average_rating_30_days }}</td>
+        <td>{{ operator.average_rating_90_days }}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Grouped performance by past seven days, 30 days, and 90 days. I ditched the idea of doing it weekly, monthly, and yearly as that would require determining what the week or year is. It is much easier just to take the current date and subtract N days from it!